### PR TITLE
[FEAT] CD 워크플로우에 EC2 배포 자동화 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -62,3 +62,49 @@ jobs:
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
           echo "image_tag=$IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Deploy to EC2 via SSM
+        env:
+          IMAGE_TAG: ${{ steps.build-image.outputs.image_tag }}
+        run: |
+          COMMAND_ID=$(aws ssm send-command \
+            --region "$AWS_REGION" \
+            --instance-ids "${{ secrets.EC2_INSTANCE_ID }}" \
+            --document-name "AWS-RunShellScript" \
+            --parameters "commands=['/opt/catxi/deploy.sh $IMAGE_TAG']" \
+            --comment "Deploy $IMAGE_TAG from GitHub Actions" \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "SSM Command ID: $COMMAND_ID"
+
+          # Wait for command to complete (max 5 minutes)
+          for i in $(seq 1 30); do
+            STATUS=$(aws ssm get-command-invocation \
+              --region "$AWS_REGION" \
+              --command-id "$COMMAND_ID" \
+              --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+              --query "Status" \
+              --output text 2>/dev/null || echo "Pending")
+
+            echo "[$i/30] Status: $STATUS"
+
+            if [ "$STATUS" = "Success" ]; then
+              echo "Deploy succeeded."
+              exit 0
+            elif [ "$STATUS" = "Failed" ] || [ "$STATUS" = "Cancelled" ] || [ "$STATUS" = "TimedOut" ]; then
+              aws ssm get-command-invocation \
+                --region "$AWS_REGION" \
+                --command-id "$COMMAND_ID" \
+                --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+                --query "StandardErrorContent" \
+                --output text
+              echo "Deploy failed with status: $STATUS"
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          echo "Deploy timed out after 5 minutes"
+          exit 1


### PR DESCRIPTION
## #️⃣연관된 이슈

> #5

## 📝작업 내용

main 브랜치 push 시 ECR 이미지 push 이후 EC2까지 자동 배포되도록 CD 파이프라인을 완성합니다.

**커밋 1 — docker build 중복 제거 및 step output 수정**
- 동일 소스를 두 번 빌드하던 비효율 제거
- 한 번의 `docker build`에 `sha`/`latest` 두 태그 동시 부여
- `build-image` step에 `id` 추가 및 `image_tag` output으로 sha 전달

**커밋 2 — SSM send-command로 EC2 배포 자동화 추가**
- ECR push 완료 후 AWS SSM을 통해 EC2의 `/opt/catxi/deploy.sh` 원격 실행
- git sha 태그를 인수로 전달하여 정확한 이미지 버전 배포
- SSM 명령 완료까지 최대 5분 polling (10초 간격)
- 실패/취소/타임아웃 시 stderr 출력 후 워크플로우 실패 처리

> **필요한 GitHub Secrets 추가 필요**
> - `EC2_INSTANCE_ID` : 배포 대상 EC2 인스턴스 ID
> - IAM 사용자에 `ssm:SendCommand`, `ssm:GetCommandInvocation` 권한 추가 필요

## 💬리뷰 요구사항(선택)

- SSM polling 간격(10초)과 최대 대기 시간(5분)이 적절한지 확인 부탁드립니다