### PR TITLE
[PERF] Spring Boot Graceful Shutdown 설정 (#17)

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -2,6 +2,8 @@ spring:
   config:
     activate:
       on-profile: prod
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
   datasource:
     url: jdbc:mysql://${DB_HOST}:${DB_PORT}/catxi?allowPublicKeyRetrieval=true&useSSL=true&serverTimezone=Asia/Seoul&useLegacyDatetimeCode=false&connectionTimeZone=Asia/Seoul&autoReconnect=true&useUnicode=true&characterEncoding=UTF-8
     username: ${DB_USER}
@@ -85,6 +87,7 @@ fcm:
 
 server:
   port: 8080
+  shutdown: graceful
   tomcat:
     threads:
       max: 100


### PR DESCRIPTION
## 관련 이슈
closes #17

## 변경 내용

### `application-prod.yml`
- `server.shutdown: graceful` 추가
  - SIGTERM 수신 시 새 요청 거부, 진행 중 요청·WebSocket 세션 완료 후 종료
- `spring.lifecycle.timeout-per-shutdown-phase: 30s` 추가
  - ALB deregistration_delay(30s)와 동일하게 설정하여 드레이닝 완료 시점과 shutdown 완료 시점 동기화

## 흐름

```
ALB deregister (infra repo PR)
  → 30s 드레이닝 (기존 연결 처리)
    → docker stop --time 35 (SIGTERM 전송)
      → Spring graceful shutdown (최대 30s 대기)
        → 프로세스 정상 종료
          → docker run (새 컨테이너)
            → health check UP
              → ALB register
```

## 연관 변경 (infra repo)
- ALB `deregistration_delay`: 300s → 30s
- ALB health_check `interval`: 30s → 15s
- `deploy.sh`: ALB deregister → drain → deploy → register 순서 구현