### PR TITLE
fix: CorsConfig 복구 및 프론트 연동 설정

### DIFF
--- a/src/main/java/com/project/catxi/common/config/CorsConfig.java
+++ b/src/main/java/com/project/catxi/common/config/CorsConfig.java
@@ -32,7 +32,10 @@ public class CorsConfig {
 
         configuration.setExposedHeaders(Arrays.asList(
             "Authorization",
-            "Content-Type"
+            "Content-Type",
+            "access",
+            "isNewUser",
+            "X-Access-Token-Refreshed"
         ));
 
         // 쿠키(refresh token) 및 Authorization 헤더 허용


### PR DESCRIPTION
## 요약

- V2 초기화 시 누락된 `CorsConfig.java` 복구 (V1에 있던 파일이 V2 init 커밋에 미포함)
- CORS 허용 origin에 `catxi.shop` 추가
- `exposedHeaders`에 프론트 연동에 필요한 헤더 추가

## 변경 내용

**허용 Origin**
```
https://catxi-university-taxi-b0936.web.app
https://catxi.shop
https://www.catxi.shop
http://localhost:3000
http://localhost:5173
```

**노출 헤더 추가**
- `access` — 로그인 응답 시 Access Token 전달
- `isNewUser` — 신규 사용자 여부 판단
- `X-Access-Token-Refreshed` — 무중단 토큰 재발급 여부

위 헤더들이 `exposedHeaders`에 없으면 브라우저 CORS 정책으로 인해 프론트에서 읽기 불가.