### PR TITLE
[FEAT] ECS Fargate FCM 키 파일 주입을 위한 Dockerfile 엔트리포인트 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
 
 EXPOSE 8080
 
-ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -cp /app:/app/lib/* com.project.catxi.CatxiApplication"]
+ENTRYPOINT ["sh", "-c", "if [ -n \"${FCM_SERVICE_ACCOUNT_JSON:-}\" ]; then echo \"$FCM_SERVICE_ACCOUNT_JSON\" > /tmp/fcm-key.json; fi && java $JAVA_OPTS -cp /app:/app/lib/* com.project.catxi.CatxiApplication"]


### PR DESCRIPTION
## Summary

ECS Fargate는 호스트 볼륨 마운트가 불가하므로, Secrets Manager에서 주입된 `FCM_SERVICE_ACCOUNT_JSON` 환경변수를 컨테이너 시작 시 파일로 변환한다.

## Changes

```dockerfile
# Before
ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -cp /app:/app/lib/* com.project.catxi.CatxiApplication"]

# After
ENTRYPOINT ["sh", "-c", "if [ -n \"${FCM_SERVICE_ACCOUNT_JSON:-}\" ]; then echo \"$FCM_SERVICE_ACCOUNT_JSON\" > /tmp/fcm-key.json; fi && java $JAVA_OPTS -cp /app:/app/lib/* com.project.catxi.CatxiApplication"]
```

## Test plan

- [ ] ECS 태스크 재배포 후 FCM 서비스 계정 파일 에러 없음 확인
- [ ] `/actuator/health` 정상 응답 확인

Closes #29